### PR TITLE
プレイヤーの当たり判定と状態遷移

### DIFF
--- a/team_GL/animationBoard.h
+++ b/team_GL/animationBoard.h
@@ -33,6 +33,5 @@ protected:
 
 	int m_nDirection;		// Œü‚« ¶F-1 ‰EF1
 
-	float m_fCollisionWidth;
-	float m_fCollisionHeight;
+	Vector2 m_Collision;
 };

--- a/team_GL/enemy.cpp
+++ b/team_GL/enemy.cpp
@@ -53,8 +53,7 @@ void CEnemy::Init(Vector3 pos, float width, float height, int texIndex)
 	m_Width = width;
 	m_Height = height;
 	m_nDirection = 1;
-	m_fCollisionWidth = ENEMY_COLLISIONWIDTH;
-	m_fCollisionHeight = ENEMY_COLLISIONHEIGHT;
+	m_Collision = Vector2(ENEMY_COLLISIONWIDTH, ENEMY_COLLISIONHEIGHT);
 	m_nTexIdx = CTexture::SetTexture(texIndex);
 }
 
@@ -121,7 +120,7 @@ void CEnemy::Create(Vector3 pos, float width, float height, int texIndex)
 ******************************************************************************/
 void CEnemy::HitCheck( Vector3 pos, float width, float height )
 {
-	if( abs( m_Pos.x - pos.x ) < m_fCollisionWidth / 2 + width / 2 && abs( m_Pos.y - pos.y ) < m_fCollisionHeight / 2 + height / 2 )
+	if( abs( m_Pos.x - pos.x ) < m_Collision.x / 2 + width / 2 && abs( m_Pos.y - pos.y ) < m_Collision.y / 2 + height / 2 )
 	{
 		this->Uninit();
 	}

--- a/team_GL/enemy.h
+++ b/team_GL/enemy.h
@@ -24,9 +24,8 @@ public:
 	void Draw(void);		//	ï`âÊä÷êîÅB
 
 	static void Create(Vector3 pos, float width, float height, int texIndex);		//	ê∂ê¨ä÷êîÅB
-	Vector3 GetPosition( void ){ return m_Pos ; };
-	float GetWidth( void ){ return m_fCollisionWidth ; };
-	float GetHeight( void ){ return m_fCollisionHeight ; };
+	Vector3 GetPosition( void ){ return m_Pos ; }
+	Vector2 GetCollision( void ){ return m_Collision ; }
 	void HitCheck( Vector3 pos, float width, float height );
 };
 

--- a/team_GL/game.cpp
+++ b/team_GL/game.cpp
@@ -82,7 +82,7 @@ void CGame::Init(void)
 	CEnemy::Create(Vector3(100.0f, 25.0f, 0.0f), 50.0f, 100.0f, TEXTURE_TYPE_ENEMY001);
 	//m_pPlayer = CPlayer::Create(Vector3(-100.0f, 0.0f, 0.0f), 50.0f, 100.0f);
 	m_pPlayer = CPlayer::Create(Vector3(-100.0f, 0.0f, 0.0f), 50.0f, 100.0f);
-	m_pPlayer->SetID(CSync::Init());
+	//m_pPlayer->SetID(CSync::Init());
 	hth =  (HANDLE)_beginthreadex(NULL,
 			0,
 			Recv,	//	スレッドとして実行する関数名

--- a/team_GL/player.h
+++ b/team_GL/player.h
@@ -25,8 +25,11 @@ public:
 	void SetID(int id) {m_PlayerID = id;}		//	ID設定。
 	int GetID(void) {return m_PlayerID;}		//	ID取得。
 
-	void HitCheck( Vector3 pos, float width, float height );
-	Vector3 GetMove(void) { return m_Move; }
+	void HitCheck( Vector3 pos, float width, float height );	// 当たり判定チェック
+	Vector3 GetMove(void) { return m_Move; }					// 移動量取得
+	void SetState(int state);									// 状態設定
+	void UpdateState(void);										// 状態更新
+	void UpdateAnimation(void);									// アニメーションの更新
 
 	static CPlayer *Create(Vector3 pos, float width, float height);	//	作成関数。
 private:
@@ -43,6 +46,7 @@ private:
 	int m_PlayerID;
 	bool m_Jump;
 
-	STATE m_State;
+	int m_nState;			// 現在の状態
+	int m_nStateCnt;		// 状態カウンタ
 	Vector3 m_Move;			// 移動量
 };


### PR DESCRIPTION
## 概要
プレイヤーの当たり判定と状態遷移を調整しました。

## デバッグ方法
ゲーム画面を起動して敵と接触したり、Gキーで攻撃したりしてみてちょ。