### PR TITLE
斬撃の当たり判定

### DIFF
--- a/team_GL/enemy.cpp
+++ b/team_GL/enemy.cpp
@@ -22,6 +22,7 @@ const int TEXTURE_ROW = 1;
 const int WALK_DRAW = 5;
 const float ENEMY_COLLISIONWIDTH = 15.0f;
 const float ENEMY_COLLISIONHEIGHT = 80.0f;
+const int HP_MAX = 100;
 
 /******************************************************************************
 	ä÷êîñº : CEnemy::CEnemy()
@@ -31,6 +32,7 @@ CEnemy::CEnemy(int Priority, OBJ_TYPE objType) : CAnimationBoard(Priority, objTy
 {
 	m_nTexRow = TEXTURE_ROW;
 	m_nTexColumn = TEXTURE_COLUMN;
+	m_Hp = HP_MAX;
 }
 
 /******************************************************************************
@@ -87,6 +89,7 @@ void CEnemy::Update(void)
 			m_nPatternAnim = 0;
 		}
 	}
+	LifeCheck();
 }
 
 /******************************************************************************
@@ -123,5 +126,19 @@ void CEnemy::HitCheck( Vector3 pos, float width, float height )
 	if( abs( m_Pos.x - pos.x ) < m_Collision.x / 2 + width / 2 && abs( m_Pos.y - pos.y ) < m_Collision.y / 2 + height / 2 )
 	{
 		this->Uninit();
+	}
+}
+
+/******************************************************************************
+ä÷êîñº : LifeCheck
+à¯êî   : void
+ñﬂÇËíl : Ç»Çµ
+ê‡ñæ   : ìñÇΩÇËîªíË
+******************************************************************************/
+void CEnemy::LifeCheck(void)
+{
+	if (m_Hp <= 0)
+	{
+		Uninit();
 	}
 }

--- a/team_GL/enemy.h
+++ b/team_GL/enemy.h
@@ -27,5 +27,10 @@ public:
 	Vector3 GetPosition( void ){ return m_Pos ; }
 	Vector2 GetCollision( void ){ return m_Collision ; }
 	void HitCheck( Vector3 pos, float width, float height );
+	void SetDamage(int damage) { m_Hp -= damage; }
+protected:
+	int m_Hp;		// ヒットポイント
+
+	void LifeCheck(void);
 };
 

--- a/team_GL/player.cpp
+++ b/team_GL/player.cpp
@@ -28,7 +28,7 @@
 /******************************************************************************
 	マクロ定義
 ******************************************************************************/
-const float MOVE_SPEED = 1.0f;								// 移動速度
+const float MOVE_SPEED = 1.3f;								// 移動速度
 const int DRAW_SPEED_WALK = 10;								// 描画スピード(歩き)
 const int DRAW_SPEED_ATTACK = 5;							// 描画スピード(攻撃)
 const int DRAW_SPEED_DAMAGE = 10;							// 描画スピード(被弾)
@@ -38,9 +38,9 @@ const int WALK_PATTERN = 4;									// 歩きモーションのコマ数
 const int ATTACK_PATTERN = 7;								// 攻撃モーションのコマ数
 const int DAMAGE_PATTERN = 2;								// 被弾モーションのコマ数
 const float MOVE_ATTENUATION = 0.2f;						// 移動量減衰係数
-const float GRAVITY = -5.0f;								// 重力
+const float GRAVITY = -0.8f;								// 重力
 const float GROUND = 0.0f;									// 地面の高さ
-const float JUMP_POWER = 30.0f;								// ジャンプ量
+const float JUMP_POWER = 15.0f;								// ジャンプ量
 const float PLAYER_COLLISIONWIDTH = 15.0f;					// 当たり判定幅
 const float PLAYER_COLLISIONHEIGHT = 80.0f;					// 当たり判定高さ
 const int ATTACK_CNT = DRAW_SPEED_ATTACK * ATTACK_PATTERN;  // 攻撃カウンタ
@@ -283,7 +283,7 @@ void CPlayer::UpdateState(void)
 	case STATE_ATTACK:
 		if (m_nStateCnt == SLASH_CNT)
 		{
-			CSlashEffect::Create(m_Pos, m_nDirection, 40.0f, 80.0f, TEXTURE_TYPE_EFFECT_SLASH);
+			CSlashEffect::Create(m_Pos, m_nDirection, 160.0f, 80.0f, TEXTURE_TYPE_EFFECT_SLASH);
 		}
 		if (m_nStateCnt >= ATTACK_CNT)
 		{

--- a/team_GL/slashEffect.cpp
+++ b/team_GL/slashEffect.cpp
@@ -15,14 +15,16 @@
 #include "scene3D.h"
 #include "animationBoard.h"
 #include "slashEffect.h"
+#include "enemy.h"
 
-const int DRAW_SPEED = 5;
-const int TEXTURE_COLUMN = 5;
-const int TEXTURE_ROW = 1;
-const int DRAW_CNT = 5;
+const int DRAW_SPEED = 5;			// 
+const int TEXTURE_COLUMN = 5;		// テクスチャ列分割数
+const int TEXTURE_ROW = 1;			// テクスチャ行分割数
+const int DRAW_CNT = 5;				// 描画速度
 const float SLASHEFFECT_COLLISIONWIDTH = 15.0f;
 const float SLASHEFFECT_COLLISIONHEIGHT = 80.0f;
-const float MOVE_SPEED = 5.0f;
+const float MOVE_SPEED = 5.0f;		// 移動速度
+const int DAMAGE_VALUE = 100;		// 与えるダメージ
 
 /******************************************************************************
 	関数名 : CSlashEffect::CSlashEffect()
@@ -56,7 +58,7 @@ void CSlashEffect::Init(Vector3 pos, int direction, float width, float height, i
 	m_Height = height;
 	m_nDirection = direction;
 	m_Move = Vector3(MOVE_SPEED, 0.0f, 0.0f) * (float)m_nDirection;
-	m_Collision = Vector2(SLASHEFFECT_COLLISIONWIDTH, SLASHEFFECT_COLLISIONHEIGHT);
+	m_Collision = Vector2(width, height);
 	m_nTexIdx = CTexture::SetTexture(texIndex);
 }
 
@@ -82,19 +84,19 @@ void CSlashEffect::Update(void)
 	// 斬撃を前に飛ばす
 	m_Pos += m_Move;
 
+	UpdateCollision();
+
 	// パターン描画更新
 	m_nCntAnim++;
-	if (m_nCntAnim == DRAW_SPEED)
+	if (m_nCntAnim % DRAW_SPEED == 0)
 	{
-		m_nCntAnim = 0;
 		m_nPatternAnim++;
 
 		// エフェクトのアニメーションが終わったら消去
-		if (m_nPatternAnim == DRAW_CNT - 1)
+		if (m_nPatternAnim % DRAW_CNT == 0)
 		{
 			Uninit();
 		}
-
 	}
 }
 
@@ -132,5 +134,30 @@ void CSlashEffect::HitCheck( Vector3 pos, float width, float height )
 	if( abs( m_Pos.x - pos.x ) < (m_Collision.x + width) * 0.5f && abs( m_Pos.y - pos.y ) <  (m_Collision.y + height) * 0.5f )
 	{
 		this->Uninit();
+	}
+}
+
+/******************************************************************************
+関数名 : UpdateCollision
+引数   : pos, width, height
+戻り値 : なし
+説明   : 当たり判定
+******************************************************************************/
+void CSlashEffect::UpdateCollision(void)
+{
+	CScene *pScene = CScene::GetList(PRIORITY_3D);
+	while (pScene)
+	{
+		if (pScene->GetObjtype(pScene) == OBJ_TYPE_ENEMY)
+		{
+			CEnemy *pEnemy = (CEnemy*)pScene;
+			Vector3 pos = pEnemy->GetPosition();
+			Vector2 collision = pEnemy->GetCollision();
+			if (abs(m_Pos.x - pos.x) < (m_Collision.x + collision.x) * 0.5f && abs(m_Pos.y - pos.y) < (m_Collision.y + collision.y) * 0.5f)
+			{
+				pEnemy->SetDamage(DAMAGE_VALUE);
+			}
+		}
+		pScene = pScene->GetNext(pScene);
 	}
 }

--- a/team_GL/slashEffect.h
+++ b/team_GL/slashEffect.h
@@ -28,4 +28,6 @@ public:
 	void HitCheck( Vector3 pos, float width, float height );
 protected:
 	Vector3 m_Move;			// ˆÚ“®—Ê
+
+	void UpdateCollision(void); // “–‚½‚è”»’èXV
 };


### PR DESCRIPTION
## 概要
斬撃に敵への当たり判定を追加

## 確認方法
ゲーム画面でGキー押して攻撃して敵に当ててみてちょ。
敵がしにます。
そのまま画面遷移します。