### PR TITLE
プレイヤーのライフゲージの修正、死亡状態を追加、その他

### DIFF
--- a/team_GL/animationBoard.cpp
+++ b/team_GL/animationBoard.cpp
@@ -36,6 +36,7 @@ CAnimationBoard::CAnimationBoard(int Priority, OBJ_TYPE objType) : CScene3D(Prio
 	m_nDirection = -1;
 	m_nTexRow = TEXTURE_COLUMN;
 	m_nTexColumn = TEXTURE_ROW;
+	m_fAlfa = 1.0f;
 }
 
 /******************************************************************************
@@ -120,7 +121,7 @@ void CAnimationBoard::Draw(void)
 	glBegin(GL_TRIANGLE_STRIP);
 
 	//	êFê›íË
-	glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
+	glColor4f(1.0f, 1.0f, 1.0f, m_fAlfa);
 
 	//	ñ@ê¸ê›íË
 	glNormal3f(0.0f, 1.0f, 0.0f);

--- a/team_GL/animationBoard.h
+++ b/team_GL/animationBoard.h
@@ -32,4 +32,6 @@ protected:
 	int m_nRowAnim;			// 段カウンタ
 
 	int m_nDirection;		// 向き 左：-1 右：1
+
+	float m_fAlfa;			// アルファ値
 };

--- a/team_GL/fieldObject.cpp
+++ b/team_GL/fieldObject.cpp
@@ -132,8 +132,8 @@ bool CFieldObject::HitCheck(Vector3 pos, float width, float height)
 void CFieldObject::Load(void)
 {
 	// ‚PŒÂ–Ú‚Ì’n–Ê‰ò
-	CFieldObject::Create(Vector3(0.0f, 0.0f, 0.0f), Vector3(0.0f, 0.0f, 0.0f), 50.0f, 50.0f, TEXTURE_TYPE_BLOCK);
 	CFieldObject::Create(Vector3(0.0f, 25.0f, 0.0f), Vector3(0.0f, 0.0f, 0.0f), 50.0f, 50.0f, TEXTURE_TYPE_BLOCK);
+	CFieldObject::Create(Vector3(0.0f, 75.0f, 0.0f), Vector3(0.0f, 0.0f, 0.0f), 50.0f, 50.0f, TEXTURE_TYPE_BLOCK);
 
 	// ‹ó’†‰ò
 	CFieldObject::Create(Vector3(75.0f, 75.0f, 0.0f), Vector3(0.0f, 0.0f, 0.0f), 50.0f, 50.0f, TEXTURE_TYPE_BLOCK);

--- a/team_GL/player.h
+++ b/team_GL/player.h
@@ -60,8 +60,18 @@ private:
 		STATE_WALK,
 		STATE_ATTACK,
 		STATE_DAMAGE,
+		STATE_DEATH,
 		STATE_MAX
 	}STATE;
+
+	typedef enum
+	{
+		ANIM_ROW_WALK = 0,
+		ANIM_ROW_ATTACK = 1,
+		ANIM_ROW_DAMAGE = 2,
+		ANIM_ROW_DEATH = 2,
+		ANIM_ROW_MAX,
+	}ANIM_ROW;
 
 	int m_Hp;
 	int m_HpMax;
@@ -73,7 +83,8 @@ private:
 	int m_nStateCnt;		// 状態カウンタ
 	Vector3 m_Move;			// 移動量
 	Vector3 m_OldPos;		// 1フレーム前の座標
-	CScore *m_pMyscore;
+	CScore *m_pMyscore;		// スコアポインタ
+	float m_fAlfaSpeed;		// アルファ値の加減速度
 
 	void UpdateCollision(void);	// 当たり判定更新
 };

--- a/team_GL/playerLifeGauge.cpp
+++ b/team_GL/playerLifeGauge.cpp
@@ -24,6 +24,7 @@
 /******************************************************************************
 マクロ定義
 ******************************************************************************/
+const float CURRENT_ATTENUATION = 0.1f;
 
 /*******************************************************************************
 * グローバル変数
@@ -39,7 +40,7 @@
 CPlayerLifeGauge::CPlayerLifeGauge(int Priority, OBJ_TYPE objType) : CGame_UI(Priority, objType)
 {
 	m_fMax = 1.0f;
-	m_fCurrent = 1.0f;
+	m_fCurrent = m_fCurrentNext = 1.0f;
 }
 
 /*******************************************************************************
@@ -64,7 +65,8 @@ void CPlayerLifeGauge::Update(void)
 {
 	CGame *game = (CGame*)CManager::GetMode();
 	CPlayer *player = game->GetPlayer();
-	m_fCurrent = (float)player->GetLife();
+	m_fCurrentNext = (float)player->GetLife();
+	m_fCurrent += (m_fCurrentNext - m_fCurrent) * CURRENT_ATTENUATION;
 	m_fCurrent = m_fCurrent <= 0.0f ? 0.0f : m_fCurrent;
 	m_fMax = (float)player->GetLifeMax();
 }

--- a/team_GL/playerLifeGauge.h
+++ b/team_GL/playerLifeGauge.h
@@ -33,6 +33,7 @@ class CPlayerLifeGauge : public CGame_UI
 private:
 	float m_fMax;			// 最大値
 	float m_fCurrent;		// 現在の値
+	float m_fCurrentNext;	// 次の値
 public:
 	CPlayerLifeGauge(int Priority = PRIORITY_2D, OBJ_TYPE objType = OBJ_TYPE_2D);		//	コンストラクタ。
 	~CPlayerLifeGauge();


### PR DESCRIPTION
## 概要
プレイヤーのHPがゼロになったら死亡状態になるようにしました。
オフラインでも起動するように修正。

## デバッグ方法
ゲーム画面で敵に当たったり、LAN繋がないで起動してみたりしてちょうだい。